### PR TITLE
Add Codecov Report Generation

### DIFF
--- a/.github/workflows/build-master.yml
+++ b/.github/workflows/build-master.yml
@@ -41,6 +41,8 @@ jobs:
           name: Code Coverage JSON
           path: xmlutils-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        uses: codecov/codecov-action@v1
       - name: Dispatch Dependent Module Builds
         if: github.event.action != 'stdlib-publish-snapshot'
         run: |

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -35,6 +35,9 @@ jobs:
           name: Code Coverage JSON
           path: xmlutils-ballerina/target/report/test_results.json
           if-no-files-found: ignore
+      - name: Generate Codecov Report
+        if:  github.event_name == 'pull_request'
+        uses: codecov/codecov-action@v1
 
   windows-build:
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,7 @@
+fixes:
+  - "ballerina/xmldata/*/::xmldata-ballerina/"
+
+ignore:
+  - "**/tests"
+  - "xmldata-test-utils"
+


### PR DESCRIPTION
## Purpose
- Introducing `Codecov` code coverage report publishing to the `xmldata` repository

## Goals
- Publishing the testerina generated code coverage xml to `Codecov` triggered via GitHub action of PR.

## Approach
- A new job is inserted to `Pull request` GitHub actions that publishes the XML report to  `Codecov`.
- These jobs trigger on merge to master or pull request and `CodeCov` generates a descriptive code coverage report.
- `Codecov` also adds comments to any PR made based on the code coverage changes between commits

## Test environment
- Ubuntu 20.04
