### PR TITLE
Fix the double quotes issue in toJson()

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=1.0.0-alpha5-SNAPSHOT
+version=1.1.0-alpha5-SNAPSHOT
 ballerinaLangVersion=2.0.0-alpha6-SNAPSHOT
 
 checkstyleToolVersion=7.8.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=org.ballerinalang
-version=1.1.0-alpha5-SNAPSHOT
+version=1.0.0-alpha5-SNAPSHOT
 ballerinaLangVersion=2.0.0-alpha6-SNAPSHOT
 
 checkstyleToolVersion=7.8.2

--- a/xmldata-ballerina/tests/xml_to_json_test.bal
+++ b/xmldata-ballerina/tests/xml_to_json_test.bal
@@ -35,6 +35,21 @@ isolated function testFromXML() {
 @test:Config {
     groups: ["toJson"]
 }
+isolated function testtoJson() {
+    var x1 = xml `<!-- outer comment -->`;
+    var x2 = xml `<name>"supun"</name>`;
+    xml x3 = x1 + x2;
+    json|Error j = toJson(x3);
+    if (j is json) {
+        test:assertEquals(j.toJsonString(), "{\"name\":\"\\\"supun\\\"\"}", msg = "testFromXML result incorrect");
+    } else {
+        test:assertFail("testFromXML result is not json");
+    }
+}
+
+@test:Config {
+    groups: ["toJson"]
+}
 isolated function testFromXML2() {
     json|Error j = toJson(xml `foo`);
     if (j is json) {

--- a/xmldata-native/src/main/java/org/ballerinalang/stdlib/xmldata/XmlToJson.java
+++ b/xmldata-native/src/main/java/org/ballerinalang/stdlib/xmldata/XmlToJson.java
@@ -57,6 +57,7 @@ public class XmlToJson {
     private static final Type JSON_MAP_TYPE =
             TypeCreator.createMapType(TypeConstants.MAP_TNAME, PredefinedTypes.TYPE_JSON, new Module(null, null, null));
     private static final String XMLNS = "xmlns";
+    private static final String DOUBLE_QUOTES = "\"";
     private static final ArrayType JSON_ARRAY_TYPE = TypeCreator.createArrayType(PredefinedTypes.TYPE_JSON);
     public static final int NS_PREFIX_BEGIN_INDEX = BXmlItem.XMLNS_URL_PREFIX.length();
 
@@ -101,7 +102,8 @@ public class XmlToJson {
             }
             return seq;
         } else if (xml.getNodeType().equals(XmlNodeType.TEXT)) {
-            return JsonUtils.parse("\"" + xml.stringValue(null) + "\"");
+            return JsonUtils.parse(DOUBLE_QUOTES + xml.stringValue(null).replace(DOUBLE_QUOTES,
+                    "\\\"") + DOUBLE_QUOTES);
         } else {
             return newJsonMap();
         }


### PR DESCRIPTION
## Purpose
$Subject

Fixes:[#612](https://github.com/ballerina-platform/ballerina-standard-library/issues/612)
## Samples
### code
```ballerina

import ballerina/io;
import ballerina/xmldata;

public function main() {
    xml x1 = xml `<name>"Lakshan"</name>`;
    json|error jsonValue = xmldata:toJson(x1);
    io:println(jsonValue.toJsonString());
}
```
### output
```
{"name":"\"Lakshan\""}
```