### PR TITLE
Remove some limitation from the output of toRecord()

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "xmldata"
-version = "2.2.1"
+version = "2.2.2"
 authors = ["Ballerina"]
 keywords = ["xml", "json"]
 repository = "https://github.com/ballerina-platform/module-ballerina-xmldata"
@@ -10,4 +10,4 @@ license = ["Apache-2.0"]
 distribution = "2201.0.1"
 
 [[platform.java11.dependency]]
-path = "../native/build/libs/xmldata-native-2.2.1.jar"
+path = "../native/build/libs/xmldata-native-2.2.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -8,10 +8,32 @@ dependencies-toml-version = "2"
 
 [[package]]
 org = "ballerina"
+name = "io"
+version = "1.2.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"}
+]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
+
+[[package]]
+org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.value"
+version = "0.0.0"
+scope = "testOnly"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
@@ -31,6 +53,7 @@ org = "ballerina"
 name = "xmldata"
 version = "2.2.2"
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -8,32 +8,10 @@ dependencies-toml-version = "2"
 
 [[package]]
 org = "ballerina"
-name = "io"
-version = "1.2.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.value"}
-]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
-
-[[package]]
-org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.value"
-version = "0.0.0"
-scope = "testOnly"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
@@ -53,7 +31,6 @@ org = "ballerina"
 name = "xmldata"
 version = "2.2.2"
 dependencies = [
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -29,7 +29,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "xmldata"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -8,30 +8,10 @@ dependencies-toml-version = "2"
 
 [[package]]
 org = "ballerina"
-name = "io"
-version = "1.2.0"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"},
-	{org = "ballerina", name = "lang.value"}
-]
-modules = [
-	{org = "ballerina", packageName = "io", moduleName = "io"}
-]
-
-[[package]]
-org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
-]
-
-[[package]]
-org = "ballerina"
-name = "lang.value"
-version = "0.0.0"
-dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
@@ -51,7 +31,6 @@ org = "ballerina"
 name = "xmldata"
 version = "2.2.2"
 dependencies = [
-	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -8,10 +8,30 @@ dependencies-toml-version = "2"
 
 [[package]]
 org = "ballerina"
+name = "io"
+version = "1.2.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.value"}
+]
+modules = [
+	{org = "ballerina", packageName = "io", moduleName = "io"}
+]
+
+[[package]]
+org = "ballerina"
 name = "jballerina.java"
 version = "0.0.0"
 modules = [
 	{org = "ballerina", packageName = "jballerina.java", moduleName = "jballerina.java"}
+]
+
+[[package]]
+org = "ballerina"
+name = "lang.value"
+version = "0.0.0"
+dependencies = [
+	{org = "ballerina", name = "jballerina.java"}
 ]
 
 [[package]]
@@ -31,6 +51,7 @@ org = "ballerina"
 name = "xmldata"
 version = "2.2.2"
 dependencies = [
+	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}
 ]

--- a/ballerina/tests/xml_from_json_test.bal
+++ b/ballerina/tests/xml_from_json_test.bal
@@ -827,9 +827,9 @@ isolated function testfromjsonwithRecord() {
                 Zip: 300,
                 Country: "LK"
             },
-            "_attr": "attr-val",
-            "_xmlns": "example.com",
-            "_xmlns:ns": "ns.com"
+            _attr: "attr-val",
+            _xmlns: "example.com",
+            _xmlns\:ns: "ns.com"
         }
     };
     string expected = "<Invoice xmlns=\"example.com\" xmlns:ns=\"ns.com\" attr=\"attr-val\">" +

--- a/ballerina/tests/xml_to_record_test.bal
+++ b/ballerina/tests/xml_to_record_test.bal
@@ -52,41 +52,6 @@ isolated function testToRecordWithEscapedString() returns error? {
     test:assertEquals(actual, expected, msg = "testToRecordWithEscapedString result incorrect");
 }
 
-type Order record {
-    Invoice Invoice;
-};
-
-type Invoice record {
-    PurchesedItems PurchesedItems;
-    Address1 Address;
-    string _xmlns?;
-    string _xmlns\:ns?;
-    string _attr?;
-    string _ns\:attr?;
-};
-
-type PurchesedItems record {
-    Purchase[] PLine;
-};
-
-type Purchase record {
-    string|ItemCode ItemCode;
-    int Count;
-};
-
-type ItemCode record {
-    string _discount;
-    string \#content;
-};
-
-type Address1 record {
-    string StreetAddress;
-    string City;
-    int Zip;
-    string Country;
-    string _xmlns?;
-};
-
 xml e2 = xml `<Invoice xmlns="example.com" attr="attr-val" xmlns:ns="ns.com" ns:attr="ns-attr-val">
                 <PurchesedItems>
                     <PLine><ItemCode>223345</ItemCode><Count>10</Count></PLine>

--- a/ballerina/tests/xml_to_record_test.bal
+++ b/ballerina/tests/xml_to_record_test.bal
@@ -60,9 +60,9 @@ type Invoice record {
     PurchesedItems PurchesedItems;
     Address1 Address;
     string _xmlns?;
-    string _xmlns_ns?;
+    string _xmlns\:ns?;
     string _attr?;
-    string _ns_attr?;
+    string _ns\:attr?;
 };
 
 type PurchesedItems record {
@@ -76,6 +76,7 @@ type Purchase record {
 
 type ItemCode record {
     string _discount;
+    string \#content;
 };
 
 type Address1 record {
@@ -111,7 +112,7 @@ function testToRecordComplexXmlElement() returns error? {
                     {ItemCode: "223345", Count: 10},
                     {ItemCode: "223300", Count: 7},
                     {
-                        ItemCode: {"_discount": "22%", "#content": "200777"},
+                        ItemCode: {_discount: "22%", \#content: "200777"},
                         Count: 7
                     }
                 ]
@@ -124,9 +125,9 @@ function testToRecordComplexXmlElement() returns error? {
                 _xmlns: ""
             },
             _xmlns: "example.com",
-            _xmlns_ns: "ns.com",
+            _xmlns\:ns: "ns.com",
             _attr: "attr-val",
-            _ns_attr: "ns-attr-val"
+            _ns\:attr: "ns-attr-val"
         }
     };
     Order actual = check toRecord(e2);
@@ -144,7 +145,7 @@ function testToRecordComplexXmlElementWithoutPreserveNamespaces() returns error?
                     {ItemCode: "223345", Count: 10},
                     {ItemCode: "223300", Count: 7},
                     {
-                        ItemCode: {"_discount": "22%", "#content": "200777"},
+                        ItemCode: {_discount: "22%", \#content: "200777"},
                         Count: 7
                     }
                 ]
@@ -264,8 +265,8 @@ type r2 record {
 };
 
 type Root2 record {
-    string _xmlns_ns;
-    string _ns_x;
+    string _xmlns\:ns;
+    string _ns\:x;
     string _x;
 };
 
@@ -277,8 +278,8 @@ isolated function testToRecordWithMultipleAttributesAndNamespaces() returns Erro
 
     r2 expected = {
         Root: {
-            _xmlns_ns: "ns.com",
-            _ns_x: "y",
+            _xmlns\:ns: "ns.com",
+            _ns\:x: "y",
             _x: "z"
         }
     };
@@ -476,7 +477,7 @@ type BookStore2 record {
     Address3 address;
     Codes codes;
     string _status;
-    string _xmlns_ns0;
+    string _xmlns\:ns0;
 };
 
 @test:Config {
@@ -515,7 +516,7 @@ isolated function testToRecordWithNamespaces() returns error? {
             codes: {
                 item: [4, 8, 9]
             },
-            _xmlns_ns0: "http://sample.com/test",
+            _xmlns\:ns0: "http://sample.com/test",
             _status: "online"
         }
     };

--- a/ballerina/xmldata.bal
+++ b/ballerina/xmldata.bal
@@ -43,13 +43,9 @@ public type JsonOptions record {
 # + return - XML representation of the given JSON if the JSON is
 # successfully converted or else an `xmldata:Error`
 public isolated function fromJson(json jsonValue, JsonOptions options = {}) returns xml?|Error {
-    JsonOptions newOptions = {
-        arrayEntryTag: options.arrayEntryTag == "" ? "item" : options.arrayEntryTag,
-        attributePrefix: options.attributePrefix == "" ? "@" : options.attributePrefix
-    };
     if !isSingleNode(jsonValue) {
-        return getElement("root", check traverseNode(jsonValue, {}, newOptions), newOptions,
-                           check getAttributesMap(jsonValue, newOptions));
+        return getElement("root", check traverseNode(jsonValue, {}, options), options,
+                           check getAttributesMap(jsonValue, options));
     } else {
         map<json>|error jMap = jsonValue.ensureType();
         if jMap is map<json> {
@@ -58,15 +54,15 @@ public isolated function fromJson(json jsonValue, JsonOptions options = {}) retu
             }
             json value = jMap.toArray()[0];
             if value is json[] {
-                return getElement("root", check traverseNode(value, {}, newOptions, jMap.keys()[0]), newOptions,
-                                check getAttributesMap(value, newOptions));
+                return getElement("root", check traverseNode(value, {}, options, jMap.keys()[0]), options,
+                                check getAttributesMap(value, options));
             } else {
                 string key = jMap.keys()[0];
                 if key == CONTENT {
                     return xml:createText(value.toString());
                 }
-                return getElement(jMap.keys()[0], check traverseNode(value, {}, newOptions), newOptions,
-                                check getAttributesMap(value, newOptions));
+                return getElement(jMap.keys()[0], check traverseNode(value, {}, options), options,
+                                check getAttributesMap(value, options));
             }
         }
         if jsonValue !is null {

--- a/ballerina/xmldata.bal
+++ b/ballerina/xmldata.bal
@@ -43,9 +43,13 @@ public type JsonOptions record {
 # + return - XML representation of the given JSON if the JSON is
 # successfully converted or else an `xmldata:Error`
 public isolated function fromJson(json jsonValue, JsonOptions options = {}) returns xml?|Error {
+    JsonOptions newOptions = {
+        arrayEntryTag: options.arrayEntryTag == "" ? "item" : options.arrayEntryTag,
+        attributePrefix: options.attributePrefix == "" ? "@" : options.attributePrefix
+    };
     if !isSingleNode(jsonValue) {
-        return getElement("root", check traverseNode(jsonValue, {}, options),
-                           check getAttributesMap(jsonValue, options = options));
+        return getElement("root", check traverseNode(jsonValue, {}, newOptions), newOptions,
+                           check getAttributesMap(jsonValue, newOptions));
     } else {
         map<json>|error jMap = jsonValue.ensureType();
         if jMap is map<json> {
@@ -54,15 +58,15 @@ public isolated function fromJson(json jsonValue, JsonOptions options = {}) retu
             }
             json value = jMap.toArray()[0];
             if value is json[] {
-                return getElement("root", check traverseNode(value, {}, options, jMap.keys()[0]),
-                                check getAttributesMap(value, options = options));
+                return getElement("root", check traverseNode(value, {}, newOptions, jMap.keys()[0]), newOptions,
+                                check getAttributesMap(value, newOptions));
             } else {
                 string key = jMap.keys()[0];
                 if key == CONTENT {
                     return xml:createText(value.toString());
                 }
-                return getElement(jMap.keys()[0], check traverseNode(value, {}, options),
-                                check getAttributesMap(value, options = options));
+                return getElement(jMap.keys()[0], check traverseNode(value, {}, newOptions), newOptions,
+                                check getAttributesMap(value, newOptions));
             }
         }
         if jsonValue !is null {
@@ -73,23 +77,22 @@ public isolated function fromJson(json jsonValue, JsonOptions options = {}) retu
     }
 }
 
-isolated function traverseNode(json jNode, map<string> parentNamespaces, JsonOptions options = {},
+isolated function traverseNode(json jNode, map<string> parentNamespaces, JsonOptions options,
                                 string? key = ()) returns xml|Error {
-    string arrayEntryTag = options.arrayEntryTag == "" ? "item" : options.arrayEntryTag;
-    string attributePrefix = options.attributePrefix == "" ? "@" : options.attributePrefix;
     xml xNode = xml ``;
     if jNode is map<json> {
         foreach [string, json] [k, v] in jNode.entries() {
-            if !k.startsWith(attributePrefix) {
+            if !k.startsWith(options.attributePrefix) {
                 if k == CONTENT {
                     xNode += xml:createText(v.toString());
                 } else if v is json[] {
-                    xml node = check traverseNode(v, check getNamespacesMap(v, parentNamespaces, options), options, k);
+                    xml node = check traverseNode(v, check getNamespacesMap(v, options, parentNamespaces), options, k);
                     xNode += node;
                 } else {
                     xml node = check getElement(k, check traverseNode(v,
-                                                check getNamespacesMap(v, parentNamespaces, options), options),
-                    check getAttributesMap(v, parentNamespaces, options = options));
+                                                check getNamespacesMap(v, options, parentNamespaces), options),
+                                                options,
+                                                check getAttributesMap(v, options, parentNamespaces));
                     xNode += node;
                 }
             }
@@ -100,11 +103,12 @@ isolated function traverseNode(json jNode, map<string> parentNamespaces, JsonOpt
             if (key is string) {
                 arrayEntryTagKey = key;
             } else {
-                arrayEntryTagKey = arrayEntryTag;
+                arrayEntryTagKey = options.arrayEntryTag;
             }
             xml item = check getElement(arrayEntryTagKey, check traverseNode(i,
-                                        check getNamespacesMap(i, parentNamespaces, options)),
-                                        check getAttributesMap(i, parentNamespaces, options = options));
+                                        check getNamespacesMap(i, options, parentNamespaces), options),
+                                        options,
+                                        check getAttributesMap(i, options, parentNamespaces));
             xNode += item;
         }
     } else {
@@ -124,9 +128,9 @@ isolated function isSingleNode(json node) returns boolean {
     return true;
 }
 
-isolated function getElement(string name, xml children, map<string> attributes = {}, JsonOptions options = {})
+isolated function getElement(string name, xml children, JsonOptions options, map<string> attributes = {})
                         returns xml|Error {
-    string attributePrefix = options.attributePrefix == "" ? "@" : options.attributePrefix;
+    string attributePrefix = options.attributePrefix;
     xml:Element element;
     int? index = name.indexOf(":");
     if index is int {
@@ -149,9 +153,9 @@ isolated function getElement(string name, xml children, map<string> attributes =
     return element;
 }
 
-isolated function getAttributesMap(json jTree, map<string> parentNamespaces = {}, JsonOptions options = {})
+isolated function getAttributesMap(json jTree, JsonOptions options, map<string> parentNamespaces = {})
                             returns map<string>|Error {
-    string attributePrefix = options.attributePrefix == "" ? "@" : options.attributePrefix;
+    string attributePrefix = options.attributePrefix;
     map<string> attributes = parentNamespaces.clone();
     map<json>|error attr = jTree.ensureType();
     if attr is map<json> {
@@ -160,9 +164,12 @@ isolated function getAttributesMap(json jTree, map<string> parentNamespaces = {}
                 if v is map<json> || v is json[] {
                     return error Error("attribute cannot be an object or array");
                 }
-                if k.startsWith(attributePrefix + "xmlns") {
-                    string prefix = k.substring(<int>k.indexOf(":") + 1);
-                    attributes[string `{${XMLNS_NAMESPACE_URI}}${prefix}`] = v.toString();
+                int? index = k.indexOf(":");
+                if index is int {
+                    if k.startsWith(attributePrefix + "xmlns") {
+                        string prefix = k.substring(index + 1);
+                        attributes[string `{${XMLNS_NAMESPACE_URI}}${prefix}`] = v.toString();
+                    }
                 } else {
                     attributes[k.substring(1)] = v.toString();
                 }
@@ -172,20 +179,25 @@ isolated function getAttributesMap(json jTree, map<string> parentNamespaces = {}
     return attributes;
 }
 
-isolated function getNamespacesMap(json jTree, map<string> parentNamespaces = {}, JsonOptions options = {})
+isolated function getNamespacesMap(json jTree, JsonOptions options, map<string> parentNamespaces = {})
                             returns map<string>|Error {
-    string attributePrefix = options.attributePrefix == "" ? "@" : options.attributePrefix;
+    string attributePrefix = options.attributePrefix;
     map<string> namespaces = parentNamespaces.clone();
     map<json>|error attr = jTree.ensureType();
     if attr is map<json> {
         foreach [string, json] [k, v] in attr.entries() {
             if k.startsWith(attributePrefix) {
                 if v is map<json> || v is json[] {
-                    return error Error("attribute cannot be an object or array");
+                    return error Error("attribute cannot be an object or array.");
                 }
                 if k.startsWith(attributePrefix + "xmlns") {
-                    string prefix = k.substring(<int>k.indexOf(":") + 1);
-                    namespaces[string `{${XMLNS_NAMESPACE_URI}}${prefix}`] = v.toString();
+                    int? index = k.indexOf(":");
+                    if index is int {
+                        string prefix = k.substring(index + 1);
+                        namespaces[string `{${XMLNS_NAMESPACE_URI}}${prefix}`] = v.toString();
+                    } else {
+                        namespaces[string `{${XMLNS_NAMESPACE_URI}}`] = v.toString();
+                    }
                 }
             }
         }

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [[2406] Add `toRecord` function which converts an XML to a Record](https://github.com/ballerina-platform/ballerina-standard-library/issues/2406)
+
+### Fixed
+- [Fix the limitations of using the colon in the output of the `toRecord`](https://github.com/ballerina-platform/module-ballerina-xmldata/pull/418)
+
+## [2.1.0] - 2021-12-13
+
+### Added
+- [Add `toRecord` function which converts an XML to a Record](https://github.com/ballerina-platform/ballerina-standard-library/issues/2406)
 
 ## [1.1.0-alpha6] - 2021-04-02
 

--- a/docs/spec/spec.md
+++ b/docs/spec/spec.md
@@ -24,7 +24,7 @@ The conforming implementation of the specification is released and included in t
     * 2.1 [Record](#23-record)
 3. [Rules](#3-rules)
     * 3.1 [Rules for XML to JSON Conversion](#31-rules-for-xml-to-json-conversion)
-    * 3.2 [Rules for XML to Record Conversion](#32-rules-for-xml-to-json-conversion)
+    * 3.2 [Rules for XML to Record Conversion](#32-rules-for-xml-to-record-conversion)
     * 3.1 [Rules for JSON to XML Conversion](#33-rules-for-json-to-xml-conversion)
 4. [Operations](#4-operations)
     * 4.1 [XML to JSON Conversion](#41-xml-to-json-conversion)
@@ -234,19 +234,6 @@ The following API returns the record to the given XML structure by configuring t
 ```ballerina
 public isolated function toRecord(xml xmlValue, boolean preserveNamespaces = true, typedesc<record {}> returnType = <>) returns returnType|Error
 ```
-
-The XML value may not have a key to convert JSON data. Hence, Ballerina uses a default key as a `#content` to handle this case.
-
-Let's consider this,
-```ballerina
-xml x3 = xml `<ns0:bookStore status="online" xmlns:ns0="http://sample.com/test">Book</ns0:bookStore>`;
-record{} result = check xmldata:toRecord(x3);
-```
-Output of this is,
-```ballerina
-{"ns0:bookStore":{"_xmlns_ns0":"http://sample.com/test","_status":"online","#content":"Book"}}
-```
-Here, `Book` does not have a key. So, JSON data introduces a key as `#content`. but it is not mapped to any field in the Ballerina record. If the user needs to convert these XML values to a Ballerina record, it should be an open record with other fields.
 
 #### 4.2.1 Sample
 

--- a/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
+++ b/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
@@ -170,9 +170,9 @@ public class XmlToJson {
         return rootNode;
     }
 
-    private static void processAttributes(BXmlItem xmlItem, String attributePrefix,
-                                      BMap<BString, Object> mapData, AttributeManager attributeManager, Type type,
-                                          String uniqueKey, boolean preserveNamespaces) {
+    private static void processAttributes(BXmlItem xmlItem, String attributePrefix, BMap<BString, Object> mapData,
+                                          AttributeManager attributeManager, Type type, String uniqueKey,
+                                          boolean preserveNamespaces) {
         LinkedHashMap<String, String> tempAttributeMap =  new LinkedHashMap<>();
         if (attributeManager.getMap().isEmpty()) {
             tempAttributeMap = collectAttributesAndNamespaces(xmlItem, preserveNamespaces);

--- a/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
+++ b/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
@@ -79,7 +79,7 @@ public class XmlToJson {
                     .getValue();
             boolean preserveNamespaces = ((Boolean) options.get(StringUtils.fromString(Constants.OPTIONS_PRESERVE_NS)));
             return convertToJSON(xml, attributePrefix, preserveNamespaces, new AttributeManager(),
-                    null, "", COLON);
+                    null, "");
         } catch (Exception e) {
             return XmlDataUtils.getError(e.getMessage());
         }
@@ -87,8 +87,7 @@ public class XmlToJson {
 
     public static Object toJson(BXml xml, boolean preserveNamespaces, Type type) {
         try {
-            return convertToJSON(xml, UNDERSCORE, preserveNamespaces, new AttributeManager(),
-                    type, "", UNDERSCORE);
+            return convertToJSON(xml, UNDERSCORE, preserveNamespaces, new AttributeManager(), type, "");
         } catch (Exception e) {
             return XmlDataUtils.getError(e.getMessage());
         }
@@ -103,18 +102,17 @@ public class XmlToJson {
      * @return JSON representation of the given xml object
      */
     public static Object convertToJSON(BXml xml, String attributePrefix, boolean preserveNamespaces,
-                                       AttributeManager attributeManager, Type type, String uniqueKey,
-                                       String namespaceDelimiter) {
+                                       AttributeManager attributeManager, Type type, String uniqueKey) {
         if (xml instanceof BXmlItem) {
             return convertElement((BXmlItem) xml, attributePrefix, preserveNamespaces, attributeManager, type,
-                    uniqueKey, namespaceDelimiter);
+                    uniqueKey);
         } else if (xml instanceof BXmlSequence) {
             BXmlSequence xmlSequence = (BXmlSequence) xml;
             if (xmlSequence.isEmpty()) {
                 return StringUtils.fromString(EMPTY_STRING);
             }
             Object seq = convertBXmlSequence(xmlSequence, attributePrefix, preserveNamespaces, attributeManager, type,
-                    uniqueKey, namespaceDelimiter);
+                    uniqueKey);
             if (seq == null) {
                 return newJsonList();
             }
@@ -137,14 +135,14 @@ public class XmlToJson {
      */
     private static Object convertElement(BXmlItem xmlItem, String attributePrefix,
                                          boolean preserveNamespaces, AttributeManager attributeManager, Type type,
-                                         String uniqueKey, String namespaceDelimiter) {
+                                         String uniqueKey) {
         BMap<BString, Object> childrenData = newJsonMap();
         processAttributes(xmlItem, attributePrefix, childrenData, attributeManager, type, uniqueKey,
-                namespaceDelimiter, preserveNamespaces);
+                preserveNamespaces);
         String uKeyValue = getUniqueKey(xmlItem, preserveNamespaces, uniqueKey);
         String keyValue = getElementKey(xmlItem, preserveNamespaces);
         Object children = convertBXmlSequence(xmlItem.getChildrenSeq(), attributePrefix,
-                preserveNamespaces, attributeManager, type, uKeyValue, namespaceDelimiter);
+                preserveNamespaces, attributeManager, type, uKeyValue);
         BMap<BString, Object> rootNode = newJsonMap();
         if (childrenData.size() > 0) {
             if (children instanceof BMap) {
@@ -174,14 +172,13 @@ public class XmlToJson {
 
     private static void processAttributes(BXmlItem xmlItem, String attributePrefix,
                                       BMap<BString, Object> mapData, AttributeManager attributeManager, Type type,
-                                          String uniqueKey, String namespaceDelimiter, boolean preserveNamespaces) {
+                                          String uniqueKey, boolean preserveNamespaces) {
         LinkedHashMap<String, String> tempAttributeMap =  new LinkedHashMap<>();
         if (attributeManager.getMap().isEmpty()) {
-            tempAttributeMap = collectAttributesAndNamespaces(xmlItem, namespaceDelimiter, preserveNamespaces);
+            tempAttributeMap = collectAttributesAndNamespaces(xmlItem, preserveNamespaces);
             attributeManager.initializeMap(tempAttributeMap);
         } else {
-            LinkedHashMap<String, String> newAttributeMap = collectAttributesAndNamespaces(xmlItem, namespaceDelimiter,
-                    preserveNamespaces);
+            LinkedHashMap<String, String> newAttributeMap = collectAttributesAndNamespaces(xmlItem, preserveNamespaces);
             LinkedHashMap<String, String> attributeMap = attributeManager.getMap();
             for (Map.Entry<String, String> entrySet : newAttributeMap.entrySet()) {
                 String key = entrySet.getKey();
@@ -259,7 +256,7 @@ public class XmlToJson {
      */
     private static Object convertBXmlSequence(BXmlSequence xmlSequence, String attributePrefix,
                                               boolean preserveNamespaces, AttributeManager attributeManager,
-                                              Type type, String uniqueKey, String namespaceDelimiter) {
+                                              Type type, String uniqueKey) {
         List<BXml> sequence = xmlSequence.getChildrenList();
         List<BXml> newSequence = new ArrayList<>();
         for (BXml value: sequence) {
@@ -272,15 +269,15 @@ public class XmlToJson {
             return null;
         }
         return convertHeterogeneousSequence(attributePrefix, preserveNamespaces, newSequence, attributeManager, type,
-                uniqueKey, namespaceDelimiter);
+                uniqueKey);
     }
 
     private static Object convertHeterogeneousSequence(String attributePrefix, boolean preserveNamespaces,
                                                        List<BXml> sequence, AttributeManager attributeManager,
-                                                       Type type, String uniqueKey, String namespaceDelimiter) {
+                                                       Type type, String uniqueKey) {
         if (sequence.size() == 1) {
             return convertToJSON(sequence.get(0), attributePrefix, preserveNamespaces, attributeManager, type,
-                    uniqueKey, namespaceDelimiter);
+                    uniqueKey);
         }
         BMap<BString, Object> mapJson = newJsonMap();
         for (BXml bxml : sequence) {
@@ -304,7 +301,7 @@ public class XmlToJson {
             } else {
                 BString elementName = fromString(getElementKey((BXmlItem) bxml, preserveNamespaces));
                 Object result = convertToJSON(bxml, attributePrefix, preserveNamespaces, attributeManager,
-                        type, uniqueKey, namespaceDelimiter);
+                        type, uniqueKey);
                 result = validateResult(result, elementName);
                 Object value = mapJson.get(elementName);
                 if (value == null) {
@@ -353,7 +350,6 @@ public class XmlToJson {
      * @param element XML element to extract attributes and namespaces
      */
     private static LinkedHashMap<String, String> collectAttributesAndNamespaces(BXmlItem element,
-                                                                                String namespaceDelimiter,
                                                                                 boolean preserveNamespaces) {
         LinkedHashMap<String, String> attributeMap = new LinkedHashMap<>();
         BMap<BString, BString> attributesMap = element.getAttributesMap();
@@ -363,14 +359,14 @@ public class XmlToJson {
             if (preserveNamespaces) {
                 if (isNamespacePrefixEntry(entry)) {
                     addNamespacePrefixAttribute(attributeMap, entry.getKey().getValue(),
-                            entry.getValue().getValue(), namespaceDelimiter);
+                            entry.getValue().getValue());
                 } else {
                     addAttributePreservingNamespace(attributeMap, nsPrefixMap, entry.getKey().getValue(),
-                            entry.getValue().getValue(), namespaceDelimiter);
+                            entry.getValue().getValue());
                 }
             } else {
                 preserveNonNamespacesAttributes(attributeMap, nsPrefixMap, entry.getKey().getValue(),
-                        entry.getValue().getValue(), namespaceDelimiter);
+                        entry.getValue().getValue());
             }
         }
         return attributeMap;
@@ -378,30 +374,27 @@ public class XmlToJson {
 
     private static void preserveNonNamespacesAttributes(LinkedHashMap<String, String> attributeMap,
                                                         Map<String, String> nsPrefixMap,
-                                                        String attributeKey, String attributeValue,
-                                                        String namespaceDelimiter) {
+                                                        String attributeKey, String attributeValue) {
         // The namespace-related key will contain the pattern as `{link}suffix`
         if (!Pattern.matches("\\{.*\\}.*", attributeKey)) {
             addAttributePreservingNamespace(attributeMap, nsPrefixMap, attributeKey,
-                    attributeValue, namespaceDelimiter);
+                    attributeValue);
         }
     }
 
     private static void addNamespacePrefixAttribute(LinkedHashMap<String, String> attributeMap,
-                                                    String attributeKey, String attributeValue,
-                                                    String namespaceDelimiter) {
+                                                    String attributeKey, String attributeValue) {
         String prefix = attributeKey.substring(NS_PREFIX_BEGIN_INDEX);
         if (prefix.equals(XMLNS)) {
             attributeMap.put(prefix, attributeValue);
         } else {
-            attributeMap.put(XMLNS + namespaceDelimiter + prefix, attributeValue);
+            attributeMap.put(XMLNS + COLON + prefix, attributeValue);
         }
     }
 
     private static void addAttributePreservingNamespace(LinkedHashMap<String, String> attributeMap,
                                                         Map<String, String> nsPrefixMap,
-                                                        String attributeKey, String attributeValue,
-                                                        String namespaceDelimiter) {
+                                                        String attributeKey, String attributeValue) {
         int nsEndIndex = attributeKey.lastIndexOf('}');
         if (nsEndIndex > 0) {
             String ns = attributeKey.substring(1, nsEndIndex);
@@ -413,7 +406,7 @@ public class XmlToJson {
             } else if (nsPrefix.equals(XMLNS)) {
                 attributeMap.put(XMLNS, attributeValue);
             } else {
-                attributeMap.put(nsPrefix + namespaceDelimiter + local, attributeValue);
+                attributeMap.put(nsPrefix + COLON + local, attributeValue);
             }
         } else {
             attributeMap.put(attributeKey, attributeValue);


### PR DESCRIPTION
## Purpose
The following limitation remove from the output of toRecord()
- Earlier name prefix separated by `_` instead of `:`. Now, this pr has removed that and allowed users to use ":".
- After this PR is merged, the User can create the closed record with the field as `\#content`.

Related to https://github.com/ballerina-platform/ballerina-standard-library/issues/2810
## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [x] Updated the spec
