### PR TITLE
Fix error from fromXml API when missing namespace annotation in the record

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,6 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
+distribution-version = "2201.5.0-20230404-105200-b8aec90e"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,6 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.5.0-20230404-105200-b8aec90e"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/tests/from_xml_test.bal
+++ b/ballerina/tests/from_xml_test.bal
@@ -899,3 +899,140 @@ isolated function testFromXmlWithEmpty5() returns error? {
     test:assertEquals(rec, output, msg = rec.toString());
     test:assertEquals((), rec.Catering?.statusCode);
 }
+
+@Namespace {
+    prefix: "ns",
+    uri: "http://sdf.com"
+}
+type Test record {
+    Test1 xs\:id;
+};
+
+
+type Test1 record {
+
+};
+
+@test:Config {
+    groups: ["fromXml"]
+}
+isolated function testFromXmlXXXX() returns error? {
+    xml data = xml `<ns:Test xmlns="example.com"
+                        xmlns:ns="http://sdf.com" status="paid">?
+                        <xs:id xmlns:xs="http://sdf.com">1</xs:id>
+                    </ns:Test>`;
+    Test output = {
+        xs\:id:{"#content": "1"},
+        "#content": "?"
+    };
+    Test rec = check fromXml(data);
+    test:assertEquals(rec, output, msg = rec.toString());
+}
+
+@Namespace {
+    prefix: "a",
+    uri: "http://xxxxxxx.com/"
+}
+type AddAccount record {
+    Account ns0\:Account;
+    AccountTemplate b\:AccountTemplate;
+};
+
+@Namespace {
+    prefix: "ns0",
+    uri: "http://xxxxxxx.com/"
+}
+type Account record {
+    StartDate b\:StartDate;
+    EndDate b\:EndDate;
+    Status ns0\:Status;
+};
+
+@Namespace {
+    prefix: "b",
+    uri: "http://asd.com/"
+}
+type EndDate record {};
+
+@Namespace {
+    prefix: "b",
+    uri: "http://xxxxxxx.com/"
+}
+type AccountTemplate record {};
+
+@Namespace {
+    prefix: "ns0",
+    uri: "http://asd.com/"
+}
+type Status record {};
+
+@Namespace {
+    prefix: "b",
+    uri: "http://asd.com/"
+}
+type StartDate record {};
+
+@test:Config {
+    groups: ["fromXml"]
+}
+isolated function testFromXmlWithComplexXml() returns error? {
+    xml data = xml `<a:AddAccount xmlns:a="http://xxxxxxx.com/">
+                        <ns0:Account xmlns:ns0="http://xxxxxxx.com/">?
+                            <b:EndDate xmlns:b="http://asd.com/">?</b:EndDate>
+                            <b:StartDate xmlns:b="http://asd.com/">?</b:StartDate>
+                            <ns0:Status xmlns:ns0="http://asd.com/">?</ns0:Status>
+                        </ns0:Account>
+                        <b:AccountTemplate xmlns:b="http://xxxxxxx.com/">?</b:AccountTemplate>
+                    </a:AddAccount>`;
+    AddAccount output = {
+        ns0\:Account:{
+            "#content": "?",
+            b\:StartDate:{"#content": "?"},
+            b\:EndDate:{"#content": "?"},
+            ns0\:Status:{"#content": "?"}
+        },
+        b\:AccountTemplate:{"#content": "?"}
+    };
+    AddAccount rec = check fromXml(data);
+    test:assertEquals(rec, output, msg = rec.toString());
+}
+
+@Namespace {
+    prefix: "a",
+    uri: "http://xxxxxxx.com/"
+}
+type AddAccount1 record {
+    Account1 ns0\:Account;
+    string b\:AccountTemplate;
+};
+
+type Account1 record {
+    string b\:StartDate;
+    string b\:EndDate;
+    string ns0\:Status;
+};
+
+@test:Config {
+    groups: ["fromXml"]
+}
+isolated function testFromXmlWithComplexXml1() returns error? {
+    xml data = xml `<a:AddAccount1 xmlns:a="http://xxxxxxx.com/">
+                        <ns0:Account xmlns:ns0="http://xxxxxxx.com/">?
+                            <b:EndDate xmlns:b="http://asd.com/">?</b:EndDate>
+                            <b:StartDate xmlns:b="http://asd.com/">?</b:StartDate>
+                            <ns0:Status xmlns:ns0="http://asd.com/">?</ns0:Status>
+                        </ns0:Account>
+                        <b:AccountTemplate xmlns:b="http://xxxxxxx.com/">?</b:AccountTemplate>
+                    </a:AddAccount1>`;
+    AddAccount1 output = {
+        ns0\:Account:{
+            "#content": "?",
+            b\:StartDate:"?",
+            b\:EndDate: "?",
+            ns0\:Status: "?"
+        },
+        b\:AccountTemplate: "?"
+    };
+    AddAccount1 rec = check fromXml(data);
+    test:assertEquals(rec, output, msg = rec.toString());
+}

--- a/ballerina/tests/from_xml_test.bal
+++ b/ballerina/tests/from_xml_test.bal
@@ -901,35 +901,6 @@ isolated function testFromXmlWithEmpty5() returns error? {
 }
 
 @Namespace {
-    prefix: "ns",
-    uri: "http://sdf.com"
-}
-type Test record {
-    Test1 xs\:id;
-};
-
-
-type Test1 record {
-
-};
-
-@test:Config {
-    groups: ["fromXml"]
-}
-isolated function testFromXmlXXXX() returns error? {
-    xml data = xml `<ns:Test xmlns="example.com"
-                        xmlns:ns="http://sdf.com" status="paid">?
-                        <xs:id xmlns:xs="http://sdf.com">1</xs:id>
-                    </ns:Test>`;
-    Test output = {
-        xs\:id:{"#content": "1"},
-        "#content": "?"
-    };
-    Test rec = check fromXml(data);
-    test:assertEquals(rec, output, msg = rec.toString());
-}
-
-@Namespace {
     prefix: "a",
     uri: "http://xxxxxxx.com/"
 }

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- [Fix the bug from fromXml API when xml elements have different namespaces](https://github.com/ballerina-platform/ballerina-standard-library/issues/4434)
+
+## [2.4.1] - 2023-03-08
+
+### Fixed
 - [Fix the mismatch error with fromXml when the XML element has no content](https://github.com/ballerina-platform/ballerina-standard-library/issues/4155)
 
 ## [2.4.0] - 2023-02-21

--- a/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
+++ b/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
@@ -335,7 +335,7 @@ public class XmlToJson {
                                                         String value, String attributePrefix) throws Exception {
         if (!attributePrefix.equals(Constants.ADD_IF_HAS_ANNOTATION)) {
             putAsFieldTypes(mapData, key, value, type);
-        } else if (annotations.size() > 0) {
+        } else if (annotations != null && annotations.size() > 0) {
             BString annotationKey = StringUtils.fromString((Constants.FIELD + key).replace(":",
                     "\\:"));
             for (BString annotationsKey : annotations.getKeys()) {
@@ -530,7 +530,7 @@ public class XmlToJson {
     private static Object convertHeterogeneousSequence(String attributePrefix, boolean preserveNamespaces,
                                                        List<BXml> sequence, Type type,
                                                        BMap<BString, BString> parentAttributeMap) throws Exception {
-        if (sequence.size() == 1) {
+        if (sequence.size() == 1 && !(type != null && type.getTag() == TypeTags.TYPE_REFERENCED_TYPE_TAG)) {
             return convertToJSON(sequence.get(0), attributePrefix, preserveNamespaces, type, parentAttributeMap);
         }
         BMap<BString, Object> mapJson = createMapValue(type);


### PR DESCRIPTION
## Purpose
$Subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4434

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
