### PR TITLE
Add escape charter when xml value has single back slash

### DIFF
--- a/ballerina/tests/from_xml_test.bal
+++ b/ballerina/tests/from_xml_test.bal
@@ -1007,3 +1007,105 @@ isolated function testFromXmlWithComplexXml1() returns error? {
     AddAccount1 rec = check fromXml(data);
     test:assertEquals(rec, output, msg = rec.toString());
 }
+
+@test:Config {
+    groups: ["fromXml"]
+}
+isolated function testFromXmlWithBackSlash() returns error? {
+    xml payload = xml `<BookStore4 status="on\line" xmlns:ns0="http://sample.com/test">
+                            <storeName>fo\o</storeName>
+                            <postalCode>94</postalCode>
+                            <isOpen>true</isOpen>
+                            <address>
+                                <street>Galle \Road</street>
+                                <city>Colombo</city>
+                                <country>Sri Lanka</country>
+                            </address>
+                            <codes>
+                                <item>4</item>
+                                <item>8</item>
+                                <item>9</item>
+                            </codes>
+                        </BookStore4>
+                        <!-- some comment -->
+                        <?doc document="book.doc"?>`;
+    BookStore4 expected = {
+        storeName: "fo\\o",
+        postalCode: 94,
+        isOpen: true,
+        address: {
+            street: "Galle \\Road",
+            city: "Colombo",
+            country: "Sri Lanka"
+        },
+        codes: {
+            item: [4, 8, 9]
+        },
+        'xmlns\:ns0: "http://sample.com/test",
+        status: "on\\line"
+    };
+    BookStore4 actual = check fromXml(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}
+
+type Book_Store record {
+    string storeName;
+    int postalCode;
+    boolean isOpen;
+    Address_ address;
+    Codes_ codes;
+    @Attribute
+    string status;
+    @Attribute
+    string 'xmlns\:ns0;
+};
+
+type Address_ record {
+    string street;
+    string city;
+    string country;
+};
+
+type Codes_ record {
+    string[] item;
+};
+
+@test:Config {
+    groups: ["fromXml"]
+}
+isolated function testFromXmlWithBackSlash1() returns error? {
+    xml payload = xml `<Book_Store status="on\\\line" xmlns:ns0="http://sample.com/test">
+                            <storeName>fo\\\o</storeName>
+                            <postalCode>94</postalCode>
+                            <isOpen>true</isOpen>
+                            <address>
+                                <street>Galle \Road</street>
+                                <city>Colombo</city>
+                                <country>Sri Lanka</country>
+                            </address>
+                            <codes>
+                                <item>item\1\\2</item>
+                                <item>item\1\3</item>
+                                <item>item\1\5</item>
+                            </codes>
+                        </Book_Store>
+                        <!-- some comment -->
+                        <?doc document="book.doc"?>`;
+    Book_Store expected = {
+        storeName: "fo\\\\\\o",
+        postalCode: 94,
+        isOpen: true,
+        address: {
+            street: "Galle \\Road",
+            city: "Colombo",
+            country: "Sri Lanka"
+        },
+        codes: {
+            item: ["item\\1\\\\2", "item\\1\\3", "item\\1\\5"]
+        },
+        'xmlns\:ns0: "http://sample.com/test",
+        status: "on\\\\\\line"
+    };
+    Book_Store actual = check fromXml(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}

--- a/ballerina/tests/xml_to_record_test.bal
+++ b/ballerina/tests/xml_to_record_test.bal
@@ -1251,3 +1251,93 @@ isolated function testToRecordWithSameAttribute() returns Error? {
     Root30 actual = check toRecord(x);
     test:assertEquals(actual, expected, msg = "testToRecordWithSameAttribute result incorrect");
 }
+
+@test:Config {
+    groups: ["toRecord"]
+}
+isolated function testToRecordWithSingleBackSlash() returns error? {
+    xml payload = xml `
+                    <bookstore status="on\line" xmlns:ns0="http://sample.com/test">
+                        <storeName>fo\o</storeName>
+                        <postalCode>94</postalCode>
+                        <isOpen>true</isOpen>
+                        <address>
+                            <street>Galle \Road</street>
+                            <city>Colombo</city>
+                            <country>Sri Lanka</country>
+                        </address>
+                        <codes>
+                            <item>4</item>
+                            <item>8</item>
+                            <item>9</item>
+                        </codes>
+                    </bookstore>
+                    <!-- some comment -->
+                    <?doc document="book.doc"?>`;
+
+    Commercial2 expected = {
+        bookstore: {
+            storeName: "fo\\o",
+            postalCode: 94,
+            isOpen: true,
+            address: {
+                street: "Galle \\Road",
+                city: "Colombo",
+                country: "Sri Lanka"
+            },
+            codes: {
+                item: [4, 8, 9]
+            },
+            _xmlns\:ns0: "http://sample.com/test",
+            _status: "on\\line"
+        }
+    };
+
+    Commercial2 actual = check toRecord(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}
+
+@test:Config {
+    groups: ["toRecord"]
+}
+isolated function testToRecordWithSingleBackSlash1() returns error? {
+    xml payload = xml `
+                    <bookstore status="on\line" xmlns:ns0="http://sample.com/test">
+                        <storeName>fo\o</storeName>
+                        <postalCode>94</postalCode>
+                        <isOpen>true</isOpen>
+                        <address>
+                            <street>Galle \Road</street>
+                            <city>Colombo</city>
+                            <country>Sri Lanka</country>
+                        </address>
+                        <codes>
+                            <item>item\1</item>
+                            <item>item\2</item>
+                            <item>item\3</item>
+                        </codes>
+                    </bookstore>
+                    <!-- some comment -->
+                    <?doc document="book.doc"?>`;
+
+    record{} expected = {
+        "bookstore": {
+            "storeName": "fo\\o",
+            "postalCode": "94",
+            "isOpen": "true",
+            "address": {
+                "street": "Galle \\Road",
+                "city": "Colombo",
+                "country": "Sri Lanka"
+            },
+            codes: {
+                "item": ["item\\1", "item\\2", "item\\3"]
+            },
+            "_xmlns:ns0": "http://sample.com/test",
+            "_status": "on\\line"
+        }
+    };
+
+    record{} actual = check toRecord(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}

--- a/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
+++ b/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
@@ -153,8 +153,7 @@ public class XmlToJson {
                 }
             }
         }
-        return JsonUtils.parse(DOUBLE_QUOTES + xml.stringValue(null).replace(DOUBLE_QUOTES,
-                "\\\"") + DOUBLE_QUOTES);
+        return fromString(xml.stringValue(null));
     }
 
     /**

--- a/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
+++ b/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
@@ -30,7 +30,6 @@ import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.types.XmlNodeType;
-import io.ballerina.runtime.api.utils.JsonUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;


### PR DESCRIPTION
## Purpose
$Subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4457
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
