### PR TITLE
Add escape charter when xml value has single back slash

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerina"
 name = "xmldata"
-version = "2.4.2"
+version = "2.4.3"
 authors = ["Ballerina"]
 keywords = ["xml", "json"]
 repository = "https://github.com/ballerina-platform/module-ballerina-xmldata"
@@ -12,5 +12,5 @@ distribution = "2201.4.0"
 [[platform.java11.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "xmldata-native"
-version = "2.4.2"
-path = "../native/build/libs/xmldata-native-2.4.2.jar"
+version = "2.4.3"
+path = "../native/build/libs/xmldata-native-2.4.3-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "xmldata-compiler-plugin"
 class = "io.ballerina.stdlib.xmldata.compiler.XmldataCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/xmldata-compiler-plugin-2.4.2.jar"
+path = "../compiler-plugin/build/libs/xmldata-compiler-plugin-2.4.3-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -29,7 +29,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "xmldata"
-version = "2.4.2"
+version = "2.4.3"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/tests/from_xml_test.bal
+++ b/ballerina/tests/from_xml_test.bal
@@ -1007,3 +1007,105 @@ isolated function testFromXmlWithComplexXml1() returns error? {
     AddAccount1 rec = check fromXml(data);
     test:assertEquals(rec, output, msg = rec.toString());
 }
+
+@test:Config {
+    groups: ["fromXml"]
+}
+isolated function testFromXmlWithBackSlash() returns error? {
+    xml payload = xml `<BookStore4 status="on\line" xmlns:ns0="http://sample.com/test">
+                            <storeName>fo\o</storeName>
+                            <postalCode>94</postalCode>
+                            <isOpen>true</isOpen>
+                            <address>
+                                <street>Galle \Road</street>
+                                <city>Colombo</city>
+                                <country>Sri Lanka</country>
+                            </address>
+                            <codes>
+                                <item>4</item>
+                                <item>8</item>
+                                <item>9</item>
+                            </codes>
+                        </BookStore4>
+                        <!-- some comment -->
+                        <?doc document="book.doc"?>`;
+    BookStore4 expected = {
+        storeName: "fo\\o",
+        postalCode: 94,
+        isOpen: true,
+        address: {
+            street: "Galle \\Road",
+            city: "Colombo",
+            country: "Sri Lanka"
+        },
+        codes: {
+            item: [4, 8, 9]
+        },
+        'xmlns\:ns0: "http://sample.com/test",
+        status: "on\\line"
+    };
+    BookStore4 actual = check fromXml(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}
+
+type Book_Store record {
+    string storeName;
+    int postalCode;
+    boolean isOpen;
+    Address_ address;
+    Codes_ codes;
+    @Attribute
+    string status;
+    @Attribute
+    string 'xmlns\:ns0;
+};
+
+type Address_ record {
+    string street;
+    string city;
+    string country;
+};
+
+type Codes_ record {
+    string[] item;
+};
+
+@test:Config {
+    groups: ["fromXml"]
+}
+isolated function testFromXmlWithBackSlash1() returns error? {
+    xml payload = xml `<Book_Store status="on\line" xmlns:ns0="http://sample.com/test">
+                            <storeName>fo\o</storeName>
+                            <postalCode>94</postalCode>
+                            <isOpen>true</isOpen>
+                            <address>
+                                <street>Galle \Road</street>
+                                <city>Colombo</city>
+                                <country>Sri Lanka</country>
+                            </address>
+                            <codes>
+                                <item>item\1\2</item>
+                                <item>item\1\3</item>
+                                <item>item\1\5</item>
+                            </codes>
+                        </Book_Store>
+                        <!-- some comment -->
+                        <?doc document="book.doc"?>`;
+    Book_Store expected = {
+        storeName: "fo\\o",
+        postalCode: 94,
+        isOpen: true,
+        address: {
+            street: "Galle \\Road",
+            city: "Colombo",
+            country: "Sri Lanka"
+        },
+        codes: {
+            item: ["item\\1\\2", "item\\1\\3", "item\\1\\5"]
+        },
+        'xmlns\:ns0: "http://sample.com/test",
+        status: "on\\line"
+    };
+    Book_Store actual = check fromXml(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}

--- a/ballerina/tests/from_xml_test.bal
+++ b/ballerina/tests/from_xml_test.bal
@@ -1074,8 +1074,8 @@ type Codes_ record {
     groups: ["fromXml"]
 }
 isolated function testFromXmlWithBackSlash1() returns error? {
-    xml payload = xml `<Book_Store status="on\line" xmlns:ns0="http://sample.com/test">
-                            <storeName>fo\o</storeName>
+    xml payload = xml `<Book_Store status="on\\\line" xmlns:ns0="http://sample.com/test">
+                            <storeName>fo\\\o</storeName>
                             <postalCode>94</postalCode>
                             <isOpen>true</isOpen>
                             <address>
@@ -1084,7 +1084,7 @@ isolated function testFromXmlWithBackSlash1() returns error? {
                                 <country>Sri Lanka</country>
                             </address>
                             <codes>
-                                <item>item\1\2</item>
+                                <item>item\1\\2</item>
                                 <item>item\1\3</item>
                                 <item>item\1\5</item>
                             </codes>
@@ -1092,7 +1092,7 @@ isolated function testFromXmlWithBackSlash1() returns error? {
                         <!-- some comment -->
                         <?doc document="book.doc"?>`;
     Book_Store expected = {
-        storeName: "fo\\o",
+        storeName: "fo\\\\\\o",
         postalCode: 94,
         isOpen: true,
         address: {
@@ -1101,10 +1101,10 @@ isolated function testFromXmlWithBackSlash1() returns error? {
             country: "Sri Lanka"
         },
         codes: {
-            item: ["item\\1\\2", "item\\1\\3", "item\\1\\5"]
+            item: ["item\\1\\\\2", "item\\1\\3", "item\\1\\5"]
         },
         'xmlns\:ns0: "http://sample.com/test",
-        status: "on\\line"
+        status: "on\\\\\\line"
     };
     Book_Store actual = check fromXml(payload);
     test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");

--- a/ballerina/tests/xml_to_json_test.bal
+++ b/ballerina/tests/xml_to_json_test.bal
@@ -689,7 +689,7 @@ isolated function testComplexXmlWithNamespace4() returns error? {
     groups: ["toJson"]
 }
 function testToJsonComplexXmlElementWithBackSlash() returns Error? {
-    xml e = xml `<Invoice xmlns="exa\mple.com" attr="at\tr-val" xmlns:ns="ns.com" ns:attr="ns\-attr-val">
+    xml e = xml `<Invoice xmlns="exa\\\\mple.com" attr="at\tr-val" xmlns:ns="ns.com" ns:attr="ns\-attr-val">
                     <PurchesedItems>
                         <PLine><ItemCode>22\3345</ItemCode><Count>10</Count></PLine>
                         <PLine><ItemCode>22\3300</ItemCode><Count>7</Count></PLine>
@@ -723,7 +723,7 @@ function testToJsonComplexXmlElementWithBackSlash() returns Error? {
                 "@xmlns": ""
             },
             "@xmlns:ns": "ns.com",
-            "@xmlns": "exa\\mple.com",
+            "@xmlns": "exa\\\\\\\\mple.com",
             "@attr": "at\\tr-val",
             "@ns:attr": "ns\\-attr-val"
         }

--- a/ballerina/tests/xml_to_json_test.bal
+++ b/ballerina/tests/xml_to_json_test.bal
@@ -684,3 +684,49 @@ isolated function testComplexXmlWithNamespace4() returns error? {
         }
     });
 }
+
+@test:Config {
+    groups: ["toJson"]
+}
+function testToJsonComplexXmlElementWithBackSlash() returns Error? {
+    xml e = xml `<Invoice xmlns="exa\mple.com" attr="at\tr-val" xmlns:ns="ns.com" ns:attr="ns\-attr-val">
+                    <PurchesedItems>
+                        <PLine><ItemCode>22\3345</ItemCode><Count>10</Count></PLine>
+                        <PLine><ItemCode>22\3300</ItemCode><Count>7</Count></PLine>
+                        <PLine><ItemCode discount="2\2%">200\777</ItemCode><Count>7</Count></PLine>
+                    </PurchesedItems>
+                    <Address xmlns="">
+                        <StreetAddress>20, Palm \grove, Colombo 3</StreetAddress>
+                        <City>Col\ombo</City>
+                        <Zip>00300</Zip>
+                        <Country>LK</Country>
+                    </Address>
+                  </Invoice>`;
+    json j = check toJson(e);
+    json expectedOutput = {
+        Invoice: {
+            PurchesedItems: {
+                PLine: [
+                    {ItemCode: "22\\3345", Count: "10"},
+                    {ItemCode: "22\\3300", Count: "7"},
+                    {
+                        ItemCode: {"@discount": "2\\2%", "#content": "200\\777"},
+                        Count: "7"
+                    }
+                ]
+            },
+            Address: {
+                StreetAddress: "20, Palm \\grove, Colombo 3",
+                City: "Col\\ombo",
+                Zip: "00300",
+                Country: "LK",
+                "@xmlns": ""
+            },
+            "@xmlns:ns": "ns.com",
+            "@xmlns": "exa\\mple.com",
+            "@attr": "at\\tr-val",
+            "@ns:attr": "ns\\-attr-val"
+        }
+    };
+    test:assertEquals(j, expectedOutput, msg = "testToJsonComplexXmlElement result incorrect");
+}

--- a/ballerina/tests/xml_to_record_test.bal
+++ b/ballerina/tests/xml_to_record_test.bal
@@ -1251,3 +1251,93 @@ isolated function testToRecordWithSameAttribute() returns Error? {
     Root30 actual = check toRecord(x);
     test:assertEquals(actual, expected, msg = "testToRecordWithSameAttribute result incorrect");
 }
+
+@test:Config {
+    groups: ["toRecord"]
+}
+isolated function testToRecordWithSingleBackSlash() returns error? {
+    xml payload = xml `
+                    <bookstore status="on\line" xmlns:ns0="http://sample.com/test">
+                        <storeName>fo\o</storeName>
+                        <postalCode>94</postalCode>
+                        <isOpen>true</isOpen>
+                        <address>
+                            <street>Galle \Road</street>
+                            <city>Colombo</city>
+                            <country>Sri Lanka</country>
+                        </address>
+                        <codes>
+                            <item>4</item>
+                            <item>8</item>
+                            <item>9</item>
+                        </codes>
+                    </bookstore>
+                    <!-- some comment -->
+                    <?doc document="book.doc"?>`;
+
+    Commercial2 expected = {
+        bookstore: {
+            storeName: "fo\\o",
+            postalCode: 94,
+            isOpen: true,
+            address: {
+                street: "Galle \\Road",
+                city: "Colombo",
+                country: "Sri Lanka"
+            },
+            codes: {
+                item: [4, 8, 9]
+            },
+            _xmlns\:ns0: "http://sample.com/test",
+            _status: "on\\line"
+        }
+    };
+
+    Commercial2 actual = check toRecord(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}
+
+@test:Config {
+    groups: ["toRecord"]
+}
+isolated function testToRecordWithSingleBackSlash1() returns error? {
+    xml payload = xml `
+                    <bookstore status="on\line" xmlns:ns0="http://sample.com/test">
+                        <storeName>fo\o</storeName>
+                        <postalCode>94</postalCode>
+                        <isOpen>true</isOpen>
+                        <address>
+                            <street>Galle \Road</street>
+                            <city>Colombo</city>
+                            <country>Sri Lanka</country>
+                        </address>
+                        <codes>
+                            <item>item\1</item>
+                            <item>item\2</item>
+                            <item>item\3</item>
+                        </codes>
+                    </bookstore>
+                    <!-- some comment -->
+                    <?doc document="book.doc"?>`;
+
+    record{} expected = {
+        "bookstore": {
+            "storeName": "fo\\o",
+            "postalCode": "94",
+            "isOpen": "true",
+            "address": {
+                "street": "Galle \\Road",
+                "city": "Colombo",
+                "country": "Sri Lanka"
+            },
+            codes: {
+                "item": ["item\\1", "item\\2", "item\\3"]
+            },
+            "_xmlns:ns0": "http://sample.com/test",
+            "_status": "on\\line"
+        }
+    };
+
+    record{} actual = check toRecord(payload);
+    test:assertEquals(actual, expected, msg = "testToRecordWithNamespaces result incorrect");
+}

--- a/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
+++ b/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
@@ -30,7 +30,6 @@ import io.ballerina.runtime.api.types.TableType;
 import io.ballerina.runtime.api.types.Type;
 import io.ballerina.runtime.api.types.UnionType;
 import io.ballerina.runtime.api.types.XmlNodeType;
-import io.ballerina.runtime.api.utils.JsonUtils;
 import io.ballerina.runtime.api.utils.StringUtils;
 import io.ballerina.runtime.api.utils.TypeUtils;
 import io.ballerina.runtime.api.values.BArray;
@@ -153,8 +152,7 @@ public class XmlToJson {
                 }
             }
         }
-        String value = escapeBackSlash(xml.stringValue(null));
-        return JsonUtils.parse(DOUBLE_QUOTES + value.replace(DOUBLE_QUOTES, "\\\"") + DOUBLE_QUOTES);
+        return fromString(xml.stringValue(null));
     }
 
     /**
@@ -542,15 +540,15 @@ public class XmlToJson {
                     if (mapJson.get(fromString(CONTENT)) instanceof BString) {
                         BArray jsonList = createNewJsonList();
                         jsonList.append(mapJson.get(fromString(CONTENT)));
-                        jsonList.append(fromString(escapeBackSlash(bxml.toString().trim())));
+                        jsonList.append(fromString(bxml.toString().trim()));
                         mapJson.put(fromString(CONTENT), jsonList);
                     } else {
                         BArray jsonList = mapJson.getArrayValue(fromString(CONTENT));
-                        jsonList.append(fromString(escapeBackSlash(bxml.toString().trim())));
+                        jsonList.append(fromString(bxml.toString().trim()));
                         mapJson.put(fromString(CONTENT), jsonList);
                     }
                 } else {
-                    mapJson.put(fromString(CONTENT), fromString(escapeBackSlash(bxml.toString().trim())));
+                    mapJson.put(fromString(CONTENT), fromString(bxml.toString().trim()));
                 }
             } else {
                 BString elementName = fromString(getElementKey((BXmlItem) bxml, preserveNamespaces));
@@ -710,10 +708,6 @@ public class XmlToJson {
         }
         elementKey.append(qName.getLocalPart());
         return elementKey.toString();
-    }
-
-    private static String escapeBackSlash(String str) {
-        return str.replace("\\", "\\\\");
     }
 
     private XmlToJson() {

--- a/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
+++ b/native/src/main/java/io/ballerina/stdlib/xmldata/XmlToJson.java
@@ -153,8 +153,8 @@ public class XmlToJson {
                 }
             }
         }
-        return JsonUtils.parse(DOUBLE_QUOTES + xml.stringValue(null).replace(DOUBLE_QUOTES,
-                "\\\"") + DOUBLE_QUOTES);
+        String value = escapeBackSlash(xml.stringValue(null));
+        return JsonUtils.parse(DOUBLE_QUOTES + value.replace(DOUBLE_QUOTES, "\\\"") + DOUBLE_QUOTES);
     }
 
     /**
@@ -189,9 +189,9 @@ public class XmlToJson {
     }
 
     private static void processAttributeWithAnnotation(BXmlItem xmlItem, String attributePrefix,
-                                                        boolean preserveNamespaces, BMap<BString, Object> childrenData,
-                                                        Type fieldType, BMap<BString, BString> attributeMap,
-                                                        BMap<BString, BString> parentAttributeMap) throws Exception {
+                                                       boolean preserveNamespaces, BMap<BString, Object> childrenData,
+                                                       Type fieldType, BMap<BString, BString> attributeMap,
+                                                       BMap<BString, BString> parentAttributeMap) throws Exception {
         if (!attributePrefix.equals(Constants.SKIP_ATTRIBUTE)) {
             BMap<BString, Object> annotations = null;
             if (attributePrefix.equals(Constants.ADD_IF_HAS_ANNOTATION))  {
@@ -369,7 +369,7 @@ public class XmlToJson {
     }
 
     private static boolean isBelongingToElement(BMap<BString, BString> parentAttributeMap, BString key,
-                                                       BString value) {
+                                                BString value) {
         return parentAttributeMap.containsKey(key) && parentAttributeMap.get(key).getValue().equals(value.getValue());
     }
 
@@ -542,15 +542,15 @@ public class XmlToJson {
                     if (mapJson.get(fromString(CONTENT)) instanceof BString) {
                         BArray jsonList = createNewJsonList();
                         jsonList.append(mapJson.get(fromString(CONTENT)));
-                        jsonList.append(fromString(bxml.toString().trim()));
+                        jsonList.append(fromString(escapeBackSlash(bxml.toString().trim())));
                         mapJson.put(fromString(CONTENT), jsonList);
                     } else {
                         BArray jsonList = mapJson.getArrayValue(fromString(CONTENT));
-                        jsonList.append(fromString(bxml.toString().trim()));
+                        jsonList.append(fromString(escapeBackSlash(bxml.toString().trim())));
                         mapJson.put(fromString(CONTENT), jsonList);
                     }
                 } else {
-                    mapJson.put(fromString(CONTENT), fromString(bxml.toString().trim()));
+                    mapJson.put(fromString(CONTENT), fromString(escapeBackSlash(bxml.toString().trim())));
                 }
             } else {
                 BString elementName = fromString(getElementKey((BXmlItem) bxml, preserveNamespaces));
@@ -710,6 +710,10 @@ public class XmlToJson {
         }
         elementKey.append(qName.getLocalPart());
         return elementKey.toString();
+    }
+
+    private static String escapeBackSlash(String str) {
+        return str.replace("\\", "\\\\");
     }
 
     private XmlToJson() {


### PR DESCRIPTION
## Purpose
$Subject

Fixes: https://github.com/ballerina-platform/ballerina-standard-library/issues/4457
## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility
