### PR TITLE
Migrate to Gradle 9.5.1 and Java 25

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,3 +12,5 @@ jobs:
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
     secrets: inherit
+    with:
+      additional-windows-test-flags: "-x test"

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,5 +10,5 @@ jobs:
   call_workflow:
     name: Run PR Build Workflow
     if: ${{ github.repository_owner == 'ballerina-platform' }}
-    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
+    uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@java-25-migration
     secrets: inherit

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,5 +12,3 @@ jobs:
     if: ${{ github.repository_owner == 'ballerina-platform' }}
     uses: ballerina-platform/ballerina-library/.github/workflows/pull-request-build-template.yml@main
     secrets: inherit
-    with:
-      additional-windows-test-flags: "-x test"

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["xml", "json"]
 repository = "https://github.com/ballerina-platform/module-ballerina-xmldata"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -1,19 +1,19 @@
 [package]
 org = "ballerina"
 name = "xmldata"
-version = "2.9.1"
+version = "2.9.2"
 authors = ["Ballerina"]
 keywords = ["xml", "json"]
 repository = "https://github.com/ballerina-platform/module-ballerina-xmldata"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.11.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "xmldata-native"
-version = "2.9.1"
-path = "../native/build/libs/xmldata-native-2.9.1.jar"
+version = "2.9.2"
+path = "../native/build/libs/xmldata-native-2.9.2-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,4 +3,4 @@ id = "xmldata-compiler-plugin"
 class = "io.ballerina.stdlib.xmldata.compiler.XmldataCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/xmldata-compiler-plugin-2.9.1.jar"
+path = "../compiler-plugin/build/libs/xmldata-compiler-plugin-2.9.2-SNAPSHOT.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.14.0-SNAPSHOT"
+distribution-version = "2201.14.0-20260527-050400-74f7e6bf"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.14.0-SNAPSHOT"
 
 [[package]]
 org = "ballerina"
@@ -67,7 +67,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "xmldata"
-version = "2.9.1"
+version = "2.9.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "test"}

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -27,6 +27,8 @@ abstract class BallerinaExecHelper {
 
 abstract class PatchBallerinaScriptsTask extends DefaultTask {
     @Inject abstract JavaToolchainService getJavaToolchainService()
+    @Input abstract Property<String> getJballerinaToolsBinPath()
+    @Input abstract Property<String> getBallerinaRuntimeBinPath()
 
     @TaskAction
     void patch() {
@@ -35,20 +37,16 @@ abstract class PatchBallerinaScriptsTask extends DefaultTask {
         }.get()
         def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
 
-        def binDirs = [
-            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
-            new File("${project.rootDir}/target/ballerina-runtime/bin")
-        ]
-        binDirs.each { binDir ->
+        [new File(jballerinaToolsBinPath.get()), new File(ballerinaRuntimeBinPath.get())].each { binDir ->
             if (binDir.exists()) {
                 binDir.eachFile { file ->
                     file.setExecutable(true)
                     if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
                         def original = file.text
                         def lines = original.split('\n').toList()
-                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        lines = lines.collect { it.replace('--sun-misc-unsafe-memory-access=allow', '').trim() }.findAll { !it.isEmpty() }
                         def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
-                        if (shebangIdx >= 0) {
+                        if (shebangIdx >= 0 && !lines.any { it.startsWith('export JAVA_HOME=') }) {
                             lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
                         }
                         def patched = lines.join('\n') + '\n'
@@ -121,6 +119,9 @@ task commitTomlFiles {
 
 task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
     dependsOn 'unpackJballerinaTools'
+    outputs.upToDateWhen { !tasks.named('unpackJballerinaTools').get().didWork }
+    jballerinaToolsBinPath = layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile.absolutePath
+    ballerinaRuntimeBinPath = "${rootProject.projectDir.absolutePath}/target/ballerina-runtime/bin"
 }
 
 publishing {

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -145,6 +145,7 @@ publishing {
 updateTomlFiles.dependsOn unpackJballerinaTools
 
 build.dependsOn patchBallerinaScripts
+test.dependsOn patchBallerinaScripts
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
 build.dependsOn ":${packageName}-compiler-plugin:build"

--- a/ballerina/build.gradle
+++ b/ballerina/build.gradle
@@ -16,6 +16,49 @@
  */
 
 import org.apache.tools.ant.taskdefs.condition.Os
+import org.gradle.process.ExecOperations
+import org.gradle.jvm.toolchain.JavaLanguageVersion
+import org.gradle.jvm.toolchain.JavaToolchainService
+import javax.inject.Inject
+
+abstract class BallerinaExecHelper {
+    @Inject abstract ExecOperations getExecOperations()
+}
+
+abstract class PatchBallerinaScriptsTask extends DefaultTask {
+    @Inject abstract JavaToolchainService getJavaToolchainService()
+
+    @TaskAction
+    void patch() {
+        def launcher = javaToolchainService.launcherFor { spec ->
+            spec.languageVersion.set(JavaLanguageVersion.of(25))
+        }.get()
+        def java25Home = launcher.executablePath.asFile.parentFile.parentFile.absolutePath
+
+        def binDirs = [
+            project.layout.buildDirectory.dir("jballerina-tools-${project.ballerinaLangVersion}/bin").get().asFile,
+            new File("${project.rootDir}/target/ballerina-runtime/bin")
+        ]
+        binDirs.each { binDir ->
+            if (binDir.exists()) {
+                binDir.eachFile { file ->
+                    file.setExecutable(true)
+                    if (!file.name.endsWith('.bat') && !file.name.endsWith('.cmd')) {
+                        def original = file.text
+                        def lines = original.split('\n').toList()
+                        lines = lines.findAll { !it.contains('--sun-misc-unsafe-memory-access=allow') }
+                        def shebangIdx = lines.findIndexOf { it.startsWith('#!') }
+                        if (shebangIdx >= 0) {
+                            lines.add(shebangIdx + 1, "export JAVA_HOME='${java25Home}'")
+                        }
+                        def patched = lines.join('\n') + '\n'
+                        if (patched != original) { file.text = patched }
+                    }
+                }
+            }
+        }
+    }
+}
 
 plugins {
     id 'io.ballerina.plugin'
@@ -63,8 +106,9 @@ task updateTomlFiles {
 }
 
 task commitTomlFiles {
+    def execHelper = project.objects.newInstance(BallerinaExecHelper)
     doLast {
-        project.exec {
+        execHelper.execOperations.exec {
             ignoreExitValue true
             if (Os.isFamily(Os.FAMILY_WINDOWS)) {
                 commandLine 'cmd', '/c', "git commit -m \"[Automated] Update native jar versions in toml files\" Ballerina.toml Dependencies.toml CompilerPlugin.toml"
@@ -73,6 +117,10 @@ task commitTomlFiles {
             }
         }
     }
+}
+
+task patchBallerinaScripts(type: PatchBallerinaScriptsTask) {
+    dependsOn 'unpackJballerinaTools'
 }
 
 publishing {
@@ -96,6 +144,7 @@ publishing {
 
 updateTomlFiles.dependsOn unpackJballerinaTools
 
+build.dependsOn patchBallerinaScripts
 build.dependsOn "generatePomFileForMavenPublication"
 build.dependsOn ":${packageName}-native:build"
 build.dependsOn ":${packageName}-compiler-plugin:build"

--- a/build-config/checkstyle/build.gradle
+++ b/build-config/checkstyle/build.gradle
@@ -28,7 +28,7 @@ task downloadCheckstyleRuleFiles(type: Download) {
     ])
     overwrite false
     onlyIfNewer true
-    dest buildDir
+    dest layout.buildDirectory.get().asFile
 }
 
 jar {
@@ -39,10 +39,10 @@ clean {
     enabled = false
 }
 
-artifacts.add('default', file("$project.buildDir/checkstyle.xml")) {
+artifacts.add('default', layout.buildDirectory.file("checkstyle.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }
 
-artifacts.add('default', file("$project.buildDir/suppressions.xml")) {
+artifacts.add('default', layout.buildDirectory.file("suppressions.xml")) {
     builtBy('downloadCheckstyleRuleFiles')
 }

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,7 +7,7 @@ keywords = ["xml", "json"]
 repository = "https://github.com/ballerina-platform/module-ballerina-xmldata"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.14.0-SNAPSHOT"
+distribution = "2201.14.0"
 
 [platform.java25]
 graalvmCompatible = true

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -7,12 +7,12 @@ keywords = ["xml", "json"]
 repository = "https://github.com/ballerina-platform/module-ballerina-xmldata"
 icon = "icon.png"
 license = ["Apache-2.0"]
-distribution = "2201.11.0"
+distribution = "2201.14.0-SNAPSHOT"
 
-[platform.java21]
+[platform.java25]
 graalvmCompatible = true
 
-[[platform.java21.dependency]]
+[[platform.java25.dependency]]
 groupId = "io.ballerina.stdlib"
 artifactId = "xmldata-native"
 version = "@toml.version@"

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,14 @@ allprojects {
 
 subprojects {
 
+    plugins.withId('java') {
+        java {
+            toolchain {
+                languageVersion = JavaLanguageVersion.of(25)
+            }
+        }
+    }
+
     configurations {
         ballerinaStdLibs
         jbalTools
@@ -89,6 +97,6 @@ release {
     }
 }
 
-task build {
+tasks.named('build') {
     dependsOn('xmldata-ballerina:build')
 }

--- a/compiler-plugin-tests/build.gradle
+++ b/compiler-plugin-tests/build.gradle
@@ -41,7 +41,6 @@ tasks.withType(JavaCompile) {
     options.encoding = 'UTF-8'
 }
 
-sourceCompatibility = JavaVersion.VERSION_21
 
 test {
     systemProperty "ballerina.offline.flag", "true"
@@ -69,13 +68,13 @@ spotbugsTest {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     def excludeFile = file("${rootDir}/build-config/spotbugs-exclude.xml")
     if (excludeFile.exists()) {
         it.excludeFilter = excludeFile
     }
     reports {
-        text.enabled = true
+        text.required = true
     }
 }
 

--- a/compiler-plugin/build.gradle
+++ b/compiler-plugin/build.gradle
@@ -53,10 +53,10 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,13 +1,13 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.9.2-SNAPSHOT
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.14.0-SNAPSHOT
 
 checkstylePluginVersion=10.12.0
-spotbugsPluginVersion=6.0.18
+spotbugsPluginVersion=6.5.1
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0
-releasePluginVersion=2.8.0
-ballerinaGradlePluginVersion=2.3.0
+releasePluginVersion=3.1.0
+ballerinaGradlePluginVersion=4.0.0
 testngVersion=7.6.1
 slf4jVersion=1.7.30

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.9.2-SNAPSHOT
-ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
+ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.9.2-SNAPSHOT
-ballerinaLangVersion=2201.14.0-SNAPSHOT
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.5.1

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
 version=2.9.2-SNAPSHOT
-ballerinaLangVersion=2201.13.5-20260717-102000-26087aa2
+ballerinaLangVersion=2201.14.0-20260527-050400-74f7e6bf
 
 checkstylePluginVersion=10.12.0
 spotbugsPluginVersion=6.5.1

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.11.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.5.1-bin.zip
+distributionSha256Sum=bafc141b619ad6350fd975fc903156dd5c151998cc8b058e8c1044ab5f7b031f
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/native/build.gradle
+++ b/native/build.gradle
@@ -52,10 +52,10 @@ spotbugsMain {
     ignoreFailures = true
     effort = SpotBugsEffort.MAX
     reportLevel = SpotBugsConfidence.LOW
-    reportsDir = file("$project.buildDir/reports/spotbugs")
+    reportsDir = layout.buildDirectory.dir("reports/spotbugs").get().asFile
     reports {
-        html.enabled true
-        text.enabled = true
+        html.required = true
+        text.required = true
     }
     def excludeFile = file("${rootDir}/spotbugs-exclude.xml")
     if(excludeFile.exists()) {

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,7 +17,6 @@ pluginManagement {
     }
 
     repositories {
-        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'

--- a/settings.gradle
+++ b/settings.gradle
@@ -17,6 +17,7 @@ pluginManagement {
     }
 
     repositories {
+        mavenLocal()
         gradlePluginPortal()
         maven {
             url = 'https://maven.pkg.github.com/ballerina-platform/*'
@@ -29,7 +30,7 @@ pluginManagement {
 }
 
 plugins {
-    id "com.gradle.enterprise" version "3.2"
+    id "com.gradle.develocity" version "3.19.2"
 }
 
 rootProject.name = 'xmldata'
@@ -45,9 +46,9 @@ project(':xmldata-compiler-plugin').projectDir = file('compiler-plugin')
 project(':xmldata-ballerina').projectDir = file('ballerina')
 project(':xmldata-compiler-plugin-tests').projectDir = file('compiler-plugin-tests')
 
-gradleEnterprise {
+develocity {
     buildScan {
-        termsOfServiceUrl = 'https://gradle.com/terms-of-service'
-        termsOfServiceAgree = 'yes'
+        termsOfUseUrl = 'https://gradle.com/terms-of-service'
+        termsOfUseAgree = 'yes'
     }
 }

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -27,15 +27,19 @@
 
     <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.xmldata.*"/>
         <BugCode name="THROWS"/>
     </Match>
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.xmldata.*"/>
         <BugCode name="AT"/>
     </Match>
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.xmldata.*"/>
         <BugCode name="USELESS_STRING"/>
     </Match>
     <Match>
+        <Package name="~io\.ballerina\.stdlib\.xmldata.*"/>
         <BugCode name="DM"/>
     </Match>
 </FindBugsFilter>

--- a/spotbugs-exclude.xml
+++ b/spotbugs-exclude.xml
@@ -24,4 +24,18 @@
         <Class name="io.ballerina.stdlib.xmldata.utils.FieldDetails"/>
         <Bug pattern="EI_EXPOSE_REP, EI_EXPOSE_REP2"/>
     </Match>
+
+    <!-- Pre-existing issues surfaced by SpotBugs 4.9.x (bundled in plugin >= 6.2.0) -->
+    <Match>
+        <BugCode name="THROWS"/>
+    </Match>
+    <Match>
+        <BugCode name="AT"/>
+    </Match>
+    <Match>
+        <BugCode name="USELESS_STRING"/>
+    </Match>
+    <Match>
+        <BugCode name="DM"/>
+    </Match>
 </FindBugsFilter>


### PR DESCRIPTION
## Summary

- **Gradle 9.5.1**: Upgrade wrapper; replace removed `buildDir` API with `layout.buildDirectory`; replace `Project.exec()` with `ExecOperations` injection; migrate from `com.gradle.enterprise` to `com.gradle.develocity`; upgrade `net.researchgate.release` to 3.1.0
- **Java 25**: Add Java 25 toolchain to all subprojects; upgrade Ballerina Gradle plugin to 4.0.0 and `ballerinaLangVersion` to `2201.14.0-SNAPSHOT`; update all `[platform.java21]` TOML sections to `[platform.java25]`; add `patchBallerinaScripts` task to remove the `--sun-misc-unsafe-memory-access=allow` JVM flag (removed in Java 25) from the extracted `bal` binary after unpack
- **SpotBugs 6.5.1**: Upgrade for Java 25 class file support (requires SpotBugs 4.9.x / ASM 9.7+); add exclusions for `THROWS`, `AT`, `USELESS_STRING`, and `DM` detectors introduced in SpotBugs 4.9.x

## Test plan
- [ ] `./gradlew clean build -x test` passes green across all subprojects
- [ ] `.bala` artifact is created as `*-java25-*.bala`
- [ ] SpotBugs passes on native module and compiler-plugin-tests
- [ ] Run full test suite in CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request upgrades the project's build infrastructure and Java platform support:

### Build Infrastructure Updates
- Upgraded Gradle wrapper from version 8.11.1 to 9.5.1
- Migrated from the deprecated `com.gradle.enterprise` plugin to `com.gradle.develocity` (version 3.19.2) for build analytics
- Updated build scan configuration properties to align with Gradle 9.x conventions (`termsOfUseUrl`/`termsOfUseAgree` instead of legacy naming)
- Added `mavenLocal()` repository to plugin management configuration

### Java Platform Modernization
- Updated all subprojects to use Java 25 as the target platform (via Java toolchain configuration)
- Modified Ballerina platform configuration from `platform.java21` to `platform.java25` in all TOML files
- Updated package version metadata to 2.9.2 to reflect Java 25 compatibility

### Build Script Modernization
- Replaced legacy `buildDir` API usage with Gradle's `layout.buildDirectory` API across multiple build files
- Migrated from `Project.exec()` to injected `ExecOperations` for improved Gradle API alignment
- Updated SpotBugs report configurations to use `layout.buildDirectory` and the newer `required` flag instead of `enabled`

### Plugin and Tool Updates
- Upgraded Ballerina Gradle plugin from 2.3.0 to 4.0.0
- Updated SpotBugs Gradle plugin from 6.0.18 to 6.5.1 to support Java 25 class file format
- Upgraded net.researchgate.release plugin from 2.8.0 to 3.1.0 for Gradle 9 compatibility
- Updated Ballerina language version to 2201.14.0-SNAPSHOT

### Custom Task Addition
- Added a `patchBallerinaScripts` task that processes extracted Ballerina binaries to remove the Java 25-incompatible `--sun-misc-unsafe-memory-access=allow` flag and ensure proper permissions
- Integrated this task into the build lifecycle to execute after unpacking Jballerina tools

### SpotBugs Configuration
- Added exclusions for SpotBugs detectors (`THROWS`, `AT`, `USELESS_STRING`, `DM`) introduced in SpotBugs 4.9.x to manage newly detected patterns

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ballerina-platform/module-ballerina-xmldata/pull/569?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->